### PR TITLE
Add retries to schema sync

### DIFF
--- a/src/rabbit_lvc_plugin.erl
+++ b/src/rabbit_lvc_plugin.erl
@@ -25,7 +25,8 @@ setup_schema() ->
                          {record_name, cached},
                          {type, set},
                          {disc_copies, [node()]}]),
-    mnesia:wait_for_tables([?LVC_TABLE], 30000),
+    mnesia:add_table_copy(?LVC_TABLE, node(), disc_copies),
+    rabbit_table:wait([?LVC_TABLE]),
     ok.
 
 


### PR DESCRIPTION
So, do what RabbitMQ core does as of 3.6.7 or so.

This makes it possible for nodes with those plugins enabled to be
restarted in arbitrary order within a certain time window, just
like nodes without those plugins.

Closes #28