### PR TITLE
Fix failing test

### DIFF
--- a/src/rabbit_exchange_type_lvc.erl
+++ b/src/rabbit_exchange_type_lvc.erl
@@ -25,8 +25,8 @@ description() ->
 
 serialise_events() -> false.
 
-route(Exchange = #exchange{name = Name},
-      Delivery = #delivery{message = Msg}) ->
+route(#exchange{name = Name},
+      #delivery{message = Msg}) ->
     #basic_message{routing_keys = RKs} = Msg,
     Keys = case RKs of
                CC when is_list(CC) -> CC;
@@ -39,9 +39,9 @@ route(Exchange = #exchange{name = Name},
                                                     routing_key=K},
                                     content = Msg},
                             write) ||
-                  K <- Keys]
+               K <- Keys]
       end),
-    rabbit_exchange_type_direct:route(Exchange, Delivery).
+    rabbit_router:match_routing_key(Name, RKs).
 
 validate(_X) -> ok.
 validate_binding(_X, _B) -> ok.


### PR DESCRIPTION
Fix failing tests against rabbitmq-server master branch.

LVC exchange type does not use feature flag
`direct_exchange_routing_v2`. Therefore, route directly
via `rabbit_router:match_routing_key/2` which corresponds to "direct exchange routing v1".