### PR TITLE
Make plugin compatible with 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PROJECT = rabbitmq_lvc_exchange
 PROJECT_DESCRIPTION = RabbitMQ Last Value Cache exchange
 
-RABBITMQ_VERSION ?= v3.11.x
+RABBITMQ_VERSION ?= v3.12.x
 current_rmq_ref = $(RABBITMQ_VERSION)
 
 define PROJECT_APP_EXTRA_KEYS
-	{broker_version_requirements, ["3.11.0"]}
+	{broker_version_requirements, ["3.12.0"]}
 endef
 
 dep_amqp_client                = git_rmq-subfolder rabbitmq-erlang-client $(RABBITMQ_VERSION)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ binding key.
 
 ## Supported RabbitMQ Versions
 
-The most recent release of this plugin targets RabbitMQ 3.11.x.
-Release series earlier than 3.9 are [out of support](https://www.rabbitmq.com/versions.html).
+The most recent release of this plugin targets RabbitMQ 3.12.x.
 
 ## Supported Erlang/OTP Versions
 
-Latest version of this plugin [requires Erlang 25.0 or later versions](https://www.rabbitmq.com/which-erlang.html), same as RabbitMQ 3.11.x.
+Latest version of this plugin [requires Erlang 25.0 or later versions](https://www.rabbitmq.com/which-erlang.html), same as RabbitMQ 3.12.x.
 
 ## Installation
 

--- a/test/lvc_SUITE.erl
+++ b/test/lvc_SUITE.erl
@@ -72,6 +72,7 @@ lvc(Config) ->
     bind(Ch, X, RK, Q2),
     expect(Ch, Q1, Payload),
     expect(Ch, Q2, Payload),
+    exchange_delete(Ch, X),
     rabbit_ct_client_helpers:close_channel(Ch).
 
 lvc_bind_fanout_exchange(Config) ->
@@ -90,6 +91,7 @@ lvc_bind_fanout_exchange(Config) ->
     exchange_bind(Ch, X, RK, LvcX),
     expect(Ch, Q1, Payload),
     expect(Ch, Q2, Payload),
+    exchange_delete(Ch, X),
     rabbit_ct_client_helpers:close_channel(Ch).
 
 lvc_bind_direct_exchange(Config) ->
@@ -108,6 +110,7 @@ lvc_bind_direct_exchange(Config) ->
     exchange_bind(Ch, X, RK, LvcX),
     expect(Ch, Q1, Payload),
     expect(Ch, Q2, Payload),
+    exchange_delete(Ch, X),
     rabbit_ct_client_helpers:close_channel(Ch).
 
 
@@ -117,13 +120,15 @@ lvc_bind_direct_exchange(Config) ->
 
 exchange_declare(Ch, X) ->
     amqp_channel:call(Ch, #'exchange.declare'{exchange    = X,
-                                              type        = <<"x-lvc">>,
-                                              auto_delete = true}).
+                                              type        = <<"x-lvc">>}).
 
 exchange_declare(Ch, X, Type) ->
     amqp_channel:call(Ch, #'exchange.declare'{exchange    = X,
                                               type        = Type,
                                               auto_delete = true}).
+
+exchange_delete(Ch, X) ->
+    #'exchange.delete_ok'{} = amqp_channel:call(Ch, #'exchange.delete'{exchange = X}).
 
 queue_declare(Ch) ->
     #'queue.declare_ok'{queue = Q} =


### PR DESCRIPTION
due to https://github.com/rabbitmq/rabbitmq-server/pull/682

The test cases are modified to add code coverage for exchange deletion since previously a test case passed even though exchange deletion crashed.