### PR TITLE
Add a release workflow in GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+on:
+  push:
+    tags:
+    - v3.*
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel_otp_name:
+        - "25"
+        - "26"
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v3
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v3.3.1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: ${{ runner.os }}-repo-cache-${{ hashFiles('MODULE.bazel','WORKSPACE.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-repo-cache-
+    - name: CONFIGURE BAZEL
+      run: |
+        if [ -n "${{ secrets.BUILDBUDDY_API_KEY }}" ]; then
+        cat << EOF >> user.bazelrc
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
+        EOF
+        fi
+        cat << EOF >> user.bazelrc
+          build:buildbuddy --build_metadata=ROLE=CI
+          build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
+        EOF
+
+        bazelisk info release
+    - name: BUILD EZ
+      run: |
+        bazelisk build :ez \
+          --config=rbe-${{ matrix.bazel_otp_name }} \
+          --verbose_failures
+    - name: UPLOAD EZ
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: rabbitmq_lvc_exchange-${{ github.ref_name }}-otp-${{ matrix.bazel_otp_name }}.ez
+        path: bazel-bin/rabbitmq-lvc-exchange.ez
+        if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v3
+    - name: GET rabbitmq-server VERSION
+      id: rmq-version
+      run: |
+        sudo npm install --global --silent @bazel/buildozer
+        rmq_urls="$(cat vmware-rabbitmq/MODULE.bazel | buildozer 'print urls' -:%archive_override)"
+        echo "rmq_urls=${rmq_urls}" | tee $GITHUB_OUTPUT
+    - name: DOWNLOAD OTP 25 EZ
+      uses: actions/download-artifact@v3
+      with:
+        name: rabbitmq_lvc_exchange-${{ github.ref_name }}-otp-25.ez
+    - name: DOWNLOAD OTP 26 EZ
+      uses: actions/download-artifact@v3
+      with:
+        name: rabbitmq_lvc_exchange-${{ github.ref_name }}-otp-26.ez
+    - name: CREATE RELEASE
+      id: create-release
+      uses: ncipollo/release-action@v1.12.0
+      with:
+        allowUpdates: true
+        draft: true
+        artifactErrorsFailBuild: true
+        updateOnlyUnreleased: true
+        artifacts: rabbitmq_lvc_exchange-*.ez
+        body: |
+          rabbitmq_lvc_exchange ${{ github.ref_name }}
+
+          Built against rabbitmq-server ${{ steps.rmq-version.outputs.rmq_urls }}


### PR DESCRIPTION
When a tag matching `v3.*` is pushed, the workflow will build the .ez files and draft a github release with those files attached. Release notes can then be manually updated before publishing.