### PR TITLE
Include the otp version used to build the plugin in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
         EOF
 
         bazelisk info release
+    - name: CHECK OTP VERSION USED IN RBE
+      id: load-info
+      run: |
+        bazelisk build @rabbitmq-server//:otp_version \
+          --config=rbe-${BAZEL_OTP_NAME}
+        echo "otp=$(cat bazel-bin/external/rabbitmq-server~override/otp_version.txt)" | tee -a $GITHUB_OUTPUT
     - name: TEST
       run: |
         bazelisk test //... \
@@ -87,4 +93,6 @@ jobs:
         body: |
           rabbitmq_lvc_exchange ${{ github.ref_name }}
 
-          Built against rabbitmq-server ${{ steps.versions.outputs.rmq_urls }}
+          Built against:
+            rabbitmq-server ${{ steps.versions.outputs.rmq_urls }}
+            OTP ${{ steps.load-info.outputs.otp }}


### PR DESCRIPTION
This should be the minimum supported version for that broker release, for beam compatibility