### PR TITLE
Make plugin compatible with 3.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PROJECT = rabbitmq_lvc_exchange
 PROJECT_DESCRIPTION = RabbitMQ Last Value Cache exchange
 
-RABBITMQ_VERSION ?= v3.12.x
+RABBITMQ_VERSION ?= v3.13.x
 current_rmq_ref = $(RABBITMQ_VERSION)
 
 define PROJECT_APP_EXTRA_KEYS
-	{broker_version_requirements, ["3.12.0"]}
+	{broker_version_requirements, ["3.13.0"]}
 endef
 
 dep_amqp_client                = git_rmq-subfolder rabbitmq-erlang-client $(RABBITMQ_VERSION)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ binding key.
 
 ## Supported RabbitMQ Versions
 
-The most recent release of this plugin targets RabbitMQ 3.12.x.
+The most recent release of this plugin targets RabbitMQ 3.13.x.
+
+This plugin requires Mnesia and does not work with Khepri!
 
 ## Supported Erlang/OTP Versions
 
-Latest version of this plugin [requires Erlang 25.0 or later versions](https://www.rabbitmq.com/which-erlang.html), same as RabbitMQ 3.12.x.
+Latest version of this plugin [requires Erlang 26.0 or later versions](https://www.rabbitmq.com/which-erlang.html), same as RabbitMQ 3.13.x.
 
 ## Installation
 
@@ -89,6 +91,6 @@ reverse routing match procedure.
 
 1. Update `broker_version_requirements` in `helpers.bzl` & `Makefile` (Optional)
 1. Update the plugin version in `MODULE.bazel`
-1. Push a tag (i.e. `v3.12.0`) with the matching version
+1. Push a tag (i.e. `v3.13.0`) with the matching version
 1. Allow the Release workflow to run and create a draft release
 1. Review and publish the release


### PR DESCRIPTION
Adjust to changes in rabbit_exchange_type behaviour

I only modified `broker_version_requirements` in the Makefile as the bazel files already seem to be updated.